### PR TITLE
[L1-114] Update component short description

### DIFF
--- a/component_config/component_short_description.md
+++ b/component_config/component_short_description.md
@@ -1,1 +1,1 @@
-Google Ad Manager is an ad management platform for large publishers who have significant direct sales.
+Extracts custom reports from Google Ad Manager.


### PR DESCRIPTION
Batch cleanup of component short descriptions (the one-liner in the platform component list) - they described the vendor product instead of what the component does.

Tracked in https://linear.app/keboola/issue/L1-114/make-component-short-descriptions-consistent-support-13792 (SUPPORT-13792). Reviewed and approved by Component Factory.

Changes in this repo:
- `kds-team.ex-google-ad-manager` -> Extracts custom reports from Google Ad Manager.

One-line content change to `component_config/component_short_description.md`. Please review wording and merge.